### PR TITLE
[CS:GO] Agregar filtro pixelado a las texturas

### DIFF
--- a/csgo/materials/cs_dust/-0Sand.vmt
+++ b/csgo/materials/cs_dust/-0Sand.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/-0Sand"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/-0csSandWall.vmt
+++ b/csgo/materials/cs_dust/-0csSandWall.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/-0csSandWall"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/-2Sand.vmt
+++ b/csgo/materials/cs_dust/-2Sand.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/-2Sand"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/MltryCrteSd2.vmt
+++ b/csgo/materials/cs_dust/MltryCrteSd2.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/MltryCrteSd2"
 	$surfaceprop "metal"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/MltryCrteTp.vmt
+++ b/csgo/materials/cs_dust/MltryCrteTp.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/MltryCrteTp"
 	$surfaceprop "metal"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandCCrete.vmt
+++ b/csgo/materials/cs_dust/SandCCrete.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandCCrete"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandCrtLrgSd.vmt
+++ b/csgo/materials/cs_dust/SandCrtLrgSd.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandCrtLrgSd"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandCrtLrgTp.vmt
+++ b/csgo/materials/cs_dust/SandCrtLrgTp.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandCrtLrgTp"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandCrtSmSd.vmt
+++ b/csgo/materials/cs_dust/SandCrtSmSd.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandCrtSmSd"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandCrtSmTp.vmt
+++ b/csgo/materials/cs_dust/SandCrtSmTp.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandCrtSmTp"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandRoad.vmt
+++ b/csgo/materials/cs_dust/SandRoad.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandRoad"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandTrim.vmt
+++ b/csgo/materials/cs_dust/SandTrim.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandTrim"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandWllDoor.vmt
+++ b/csgo/materials/cs_dust/SandWllDoor.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandWllDoor"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/cs_dust/SandWllWndw.vmt
+++ b/csgo/materials/cs_dust/SandWllWndw.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "cs_dust/SandWllWndw"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/de_dust2/SandWllDoorDJ1.vmt
+++ b/csgo/materials/de_dust2/SandWllDoorDJ1.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "de_dust2/SandWllDoorDJ1"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/de_dust2/SandWllDoorDJ2.vmt
+++ b/csgo/materials/de_dust2/SandWllDoorDJ2.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "de_dust2/SandWllDoorDJ2"
 	$surfaceprop "wood"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/de_dust2/csSandWallDJ1.vmt
+++ b/csgo/materials/de_dust2/csSandWallDJ1.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "de_dust2/csSandWallDJ1"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/de_dust2/csSandWallGH1a.vmt
+++ b/csgo/materials/de_dust2/csSandWallGH1a.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "de_dust2/csSandWallGH1a"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/de_dust2/csSandWallGH1b.vmt
+++ b/csgo/materials/de_dust2/csSandWallGH1b.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "de_dust2/csSandWallGH1b"
 	$surfaceprop "concrete"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/halflife/+0~FIFTIES_LGT2.vmt
+++ b/csgo/materials/halflife/+0~FIFTIES_LGT2.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "halflife/+0~FIFTIES_LGT2"
 	$surfaceprop "glass"
+	$POINTSAMPLEMAGFILTER 1
 }

--- a/csgo/materials/halflife/GENERIC011.vmt
+++ b/csgo/materials/halflife/GENERIC011.vmt
@@ -2,4 +2,5 @@
 {
 	"$basetexture" "halflife/GENERIC011"
 	$surfaceprop "metal"
+	$POINTSAMPLEMAGFILTER 1
 }


### PR DESCRIPTION
Fueron removidas en el ultimo commit de #1 , pero fueron restauradas para la versión de Workshop.